### PR TITLE
JPA의 Save 호출을 2번 -> 1번으로 줄임

### DIFF
--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/Category.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/Category.java
@@ -52,4 +52,5 @@ public class Category extends BaseEntity {
 
     @Column(name = "order_index", nullable = false)
     private Long orderIndex;
+
 }


### PR DESCRIPTION
### 변경 사항
- 기존에는 JPA를 통해 엔티티를 저장할 때 두 번의 `save` 호출을 사용.
- 이를 한 번의 `save` 호출로 최적화하여 데이터베이스 부하를 줄이고, 코드의 간결성을 높이게 되었다.

### 변경 이유
- 두 번의 `save` 호출로 인해 불필요한 Update문이 추가로 발생하였다.
- 성능 개선과 코드 간소화를 위해 JPA `save` 호출을 한 번으로 줄이는 작업을 진행.

### 기대 효과
- 성능 향상 및 코드 간소화

Closes #2