### PR TITLE
Redis 적용, sealed 클래스 추가, 엔티티 일부 구조 변경, s3폴더 구조 변경

### DIFF
--- a/blog-springboot-jpa/build.gradle
+++ b/blog-springboot-jpa/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 
     implementation 'org.springframework.kafka:spring-kafka:3.2.4'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.5'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/blog-springboot-jpa/docker-compose.yml
+++ b/blog-springboot-jpa/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:latest
+    container_name: blog_redis
+    ports:
+      - "6379:6379"  # 로컬 포트 : 컨테이너 포트
+    volumes:
+      - redis_data:/data  # 데이터 영속성 유지
+volumes:
+  redis_data:

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/config/jwt/TokenAuthenticationFilter.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/config/jwt/TokenAuthenticationFilter.java
@@ -35,10 +35,12 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         String method = request.getMethod();
 
         // GET 요청에 대한 예외 처리
-        if (method.equals("GET") && (requestURI.equals("/api/token/initial-token") ||  // 초기 토큰을
-                // 가져오는 GET 요청이 필요 없음
-                requestURI.startsWith("/api/posts")// 특정 게시글 조회 (GET /api/posts/{id}) 및 게시글 목록
-                // 조회는 토큰 검증이 필요 없음
+        // 초기 토큰을 가져오는 GET 요청의 경우 검증 필요 없음
+        if (method.equals("GET") && (requestURI.equals("/api/token/initial-token") ||
+                //특정 게시글 조회 (GET /api/posts/{id}) 및 게시글 목록 조회는 토큰 검증이 필요 없음
+                requestURI.startsWith("/api/posts") ||
+                // 사용자가 존재하는지에 관한 userIdentifier로 조회하는 경우에도 토큰 검증이 필요 없음
+                requestURI.startsWith("/api/user")
         )) {
             // 이 경로에 대해서는 필터를 적용하지 않고 다음 필터로 넘김
             filterChain.doFilter(request, response);

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/config/jwt/TokenProvider.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/config/jwt/TokenProvider.java
@@ -46,7 +46,7 @@ public class TokenProvider {
         // 헤더 부분은 굳이 명시적으로 추가하지 않아도 된다.
         return Jwts.builder()
                 .issuer(jwtProperties.getIssuer()).issuedAt(now).expiration(expiry).subject(user.getEmail())
-                .claim("id", user.getId()).claim("roles", roles)
+                .claim("id", user.getId()).claim("userIdentifier", user.getUserIdentifier()).claim("roles", roles)
                 .signWith(jwtProperties.getJwtSecretKey()).compact();
     }
 
@@ -102,12 +102,21 @@ public class TokenProvider {
         return claims.get("id", Long.class);
     }
 
+    public String getEmailFromToken(String token) {
+        Claims claims = getClaims(token);
+        return claims.getSubject(); // sub 클레임에서 이메일 추출
+    }
+
+    public String getUserIdentifier(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("userIdentifier", String.class);
+    }
+
 
     // 페이로드, 즉 내용(클레임) 반환 메서드
     private Claims getClaims(String token) {
         try {
-
-        return Jwts.parser().verifyWith(jwtProperties.getJwtSecretKey()).build().parseSignedClaims(token).getPayload();
+            return Jwts.parser().verifyWith(jwtProperties.getJwtSecretKey()).build().parseSignedClaims(token).getPayload();
         } catch (ExpiredJwtException e) {
             return e.getClaims(); // 만료된 토큰에서도 클레임 반환
 

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/config/redis/RedisConfig.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/config/redis/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.yhs.blog.springboot.jpa.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+    @Bean
+    RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Boolean> redisTemplate() {
+        RedisTemplate<String, Boolean> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/controller/TokenApiController.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/controller/TokenApiController.java
@@ -87,7 +87,7 @@ public class TokenApiController {
 
         Long uesrId = TokenUtil.extractUserIdFromRequestToken(request, tokenProvider);
 
-        PostResponse postResponseDTO = postService.getPost(postId);
+        PostResponse postResponseDTO = postService.getPostByPostId(postId);
 
         boolean isAuthor = postResponseDTO.getUserId().equals(uesrId);
 

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/dto/ApiResponse.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/dto/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.yhs.blog.springboot.jpa.dto;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Getter;
+
+//인스턴스화 불가, 상속하는 클래스들만 인스턴스화할 수 있다. 공통된 기능만 정의
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@Getter
+public sealed abstract class ApiResponse permits SuccessResponse, ErrorResponse {
+
+    private final String message;
+
+    protected ApiResponse(String message) {
+        this.message = message;
+    }
+}

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/dto/ErrorResponse.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/dto/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.yhs.blog.springboot.jpa.dto;
+
+import lombok.Getter;
+
+// 에러 응답 CreatePost 부분에서 사용됨.
+@Getter
+public final class ErrorResponse extends ApiResponse {
+    private final int errorCode;
+
+    public ErrorResponse(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/dto/SuccessResponse.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/dto/SuccessResponse.java
@@ -1,0 +1,19 @@
+package com.yhs.blog.springboot.jpa.dto;
+
+import lombok.Getter;
+
+@Getter
+public final class SuccessResponse<T> extends ApiResponse {
+
+    private final T data;
+
+    public SuccessResponse(T data, String message) {
+        super(message);
+        this.data = data;
+    }
+
+    public SuccessResponse(String message) {
+        super(message);
+        this.data = null;
+    }
+}

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/File.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/File.java
@@ -37,4 +37,8 @@ public class File extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
 }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/PostTag.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/PostTag.java
@@ -12,10 +12,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @IdClass(PostTagId.class)  // 복합 키 클래스를
-@Table(name = "PostTags", indexes = {
-        @Index(name = "idx_post_tags_post_id", columnList = "post_id"),
-        @Index(name = "idx_post_tags_tag_id", columnList = "tag_id")
-})
+@Table(name = "PostTags")
 public class PostTag {
 
     // 여러개의 태그가 하나의 포스트에 쓰일 수 있음
@@ -30,11 +27,17 @@ public class PostTag {
     @JoinColumn(name = "tag_id")
     private Tag tag;
 
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    public static PostTag create(Post post, Tag tag) {
+
+    public static PostTag create(Post post, Tag tag, User user) {
         PostTag postTag = new PostTag();
         postTag.setPost(post);
         postTag.setTag(tag);
+        postTag.setUser(user);
         return postTag;
 
     }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/PostTagId.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/PostTagId.java
@@ -14,4 +14,5 @@ import java.io.Serializable;
 public class PostTagId implements Serializable {
     private Long post;
     private Long tag;
+    private Long user;
 }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/RefreshToken.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/RefreshToken.java
@@ -21,7 +21,7 @@ public class RefreshToken {
     @Column(name = "user_id", nullable = false, unique = true)
     private Long userId;
 
-    @Column(name = "refresh_token", nullable = false)
+    @Column(name = "refresh_token", nullable = false, length = 512, unique = true)
     private String refreshToken;
 
     public RefreshToken(Long userId, String refreshToken) {

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/User.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/entity/User.java
@@ -30,6 +30,9 @@ public class User implements UserDetails {
     @Column(nullable = false, length = 50, unique = true)
     private String username;
 
+    @Column(nullable = false, length = 50, unique = true)
+    private String userIdentifier;
+
     // OAUTH2 사용자의 경우 비밀번호를 저장할 필요가 없기 때문에 nullable true 설정
     @Column(nullable = true, length = 255)
     private String password;
@@ -51,6 +54,13 @@ public class User implements UserDetails {
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Category> categories;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<File> files;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval =
+            true)
+    private Set<PostTag> postTags;
 
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
@@ -97,10 +107,12 @@ public class User implements UserDetails {
     }
 
     @Builder
-    public User(String email, String password, String username, UserRole role, String auth) {
+    public User(String email, String password, String username, String userIdentifier,
+                UserRole role, String auth) {
         this.email = email;
         this.password = password;
         this.username = username;
+        this.userIdentifier = userIdentifier;
         this.role = role != null ? role : UserRole.USER;
     }
 

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/repository/PostRepository.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/repository/PostRepository.java
@@ -2,8 +2,16 @@ package com.yhs.blog.springboot.jpa.repository;
 
 import com.yhs.blog.springboot.jpa.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findByUserId(Long userId);
 }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/repository/TagRepository.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/repository/TagRepository.java
@@ -27,8 +27,8 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
                 SELECT pt FROM PostTag pt
                 WHERE pt.tag = t
                 AND pt.post.id <> :postId
+                AND pt.user.id <> :userId
             )
             """)
-    List<Tag> findUnusedTagsNotUsedByOtherPosts(@Param("tagNames") List<String> tagNames, @Param(
-            "postId") Long postId);
+    List<Tag> findUnusedTagsNotUsedByOtherPostsAndOtherUsers(@Param("tagNames") List<String> tagNames, @Param("postId") Long postId, @Param("userId") Long userId);
 }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/repository/UserRepository.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/repository/UserRepository.java
@@ -9,4 +9,8 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByUserIdentifier(String userIdentifier);
+
+    Boolean existsByUserIdentifier(String userIdentifier);
 }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/service/PostService.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/service/PostService.java
@@ -11,14 +11,14 @@ import java.util.List;
 
 public interface PostService {
 
-    PostResponse createPost(PostRequest postRequest, HttpServletRequest request);
+    PostResponse createNewPost(PostRequest postRequest, HttpServletRequest request);
 
-    List<PostResponse> getPostList();
+    List<PostResponse> getPostListByUserId(Long UserId);
 
-    PostResponse getPost(Long id);
+    PostResponse getPostByPostId(Long postId);
 
-    void deletePost(Long id);
+    void deletePostByPostId(Long postId);
 
-    Post updatePost(Long id, PostUpdateRequest postUpdateRequest);
+    Post updatePostByPostId(Long postId, Long userId, PostUpdateRequest postUpdateRequest);
 
 }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/service/S3Service.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/service/S3Service.java
@@ -14,6 +14,7 @@ public interface S3Service {
 //    void moveTempFilesToFinal(String tempFileUrl, String finalFolder) throws IOException;
     @Async
     void processCreatePostS3TempOperation(PostRequest postRequest);
+    @Async
     void processUpdatePostS3TempOperation(PostUpdateRequest postUpdateRequest);
 
 }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/service/UserService.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/service/UserService.java
@@ -2,9 +2,12 @@ package com.yhs.blog.springboot.jpa.service;
 
 import com.yhs.blog.springboot.jpa.dto.AddUserRequest;
 import com.yhs.blog.springboot.jpa.entity.User;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserService{
     Long createUser(AddUserRequest addUserRequest);
     User findUserById(Long userId);
     User findUserByEmail(String email);
+    boolean existsByUserIdentifier(String userIdentifier);
+    void invalidateUserCache(String userIdentifier);
 }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/service/impl/UserServiceImpl.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/service/impl/UserServiceImpl.java
@@ -1,28 +1,54 @@
 package com.yhs.blog.springboot.jpa.service.impl;
 
+import com.yhs.blog.springboot.jpa.config.jwt.TokenProvider;
 import com.yhs.blog.springboot.jpa.dto.AddUserRequest;
 import com.yhs.blog.springboot.jpa.entity.User;
 import com.yhs.blog.springboot.jpa.exception.UserCreationException;
 import com.yhs.blog.springboot.jpa.repository.UserRepository;
 import com.yhs.blog.springboot.jpa.service.UserService;
+import com.yhs.blog.springboot.jpa.util.TokenUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.TimeUnit;
+
+@Log4j2
 @RequiredArgsConstructor
 @Service
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final RedisTemplate<String, Boolean> redisTemplate;
+    private final TokenProvider tokenProvider;
+
+//    private static final long CACHE_TTL = 24 * 60 * 60; // 1일
+
+
 
 
     @Override
     public Long createUser(AddUserRequest addUserRequest) {
+        String userEmail = addUserRequest.getEmail();
+
+        String userIdentifier;
+
+        if (userEmail.contains("@")) {
+            userIdentifier = userEmail.substring(0, userEmail.indexOf('@'));
+        } else {
+            throw new IllegalArgumentException("Invalid email address: " + userEmail);
+        }
+
+
 
         try {
             BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
             User user = User.builder()
                     .username(addUserRequest.getUsername())
+                    .userIdentifier(userIdentifier)
                     .email(addUserRequest.getEmail())
                     .password(encoder.encode(addUserRequest.getPassword()))
 //                    .role(User.UserRole.ADMIN) 일단 기본값인 user로 사용
@@ -31,7 +57,7 @@ public class UserServiceImpl implements UserService {
             return userRepository.save(user).getId();
 
         } catch (Exception ex) {
-            throw new UserCreationException("사용자 생성 중 오류가 발생했습니다: " + ex.getMessage());
+            throw new UserCreationException("An error occurred while creating the user: " + ex.getMessage());
         }
     }
 
@@ -46,4 +72,31 @@ public class UserServiceImpl implements UserService {
         return userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException(
                 "User not found"));
     }
+
+    @Override
+    public boolean existsByUserIdentifier(String userIdentifier) {
+
+        String cacheKey = "user:" + userIdentifier;
+
+        Boolean exists = redisTemplate.opsForValue().get(cacheKey);
+        if (exists != null) {
+            return exists;
+        }
+
+        boolean userExists = userRepository.existsByUserIdentifier(userIdentifier);
+
+        if (userExists) {
+            // 캐시에 저장. 사용자는 회원탈퇴 하는 경우 아니면 계속 존재하기 때문에, 만료시간을 설정하지 않음. 즉 무한대.
+//            redisTemplate.opsForValue().set(cacheKey, userExists, CACHE_TTL, TimeUnit.SECONDS);
+            redisTemplate.opsForValue().set(cacheKey, userExists);
+        }
+
+        return userExists;
+    }
+
+    // 나중에 무효화할때 필요
+    public void invalidateUserCache(String userIdentifier) {
+        redisTemplate.delete("user:" + userIdentifier);
+    }
+
 }

--- a/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/util/TokenUtil.java
+++ b/blog-springboot-jpa/src/main/java/com/yhs/blog/springboot/jpa/util/TokenUtil.java
@@ -15,4 +15,26 @@ public class TokenUtil {
 
         throw new IllegalArgumentException("Invalid or missing Authorization header");
     }
+
+    public static String extractEmailFromRequestToken(HttpServletRequest request, TokenProvider tokenProvider) {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String accessToken = authorizationHeader.substring(7);
+            return tokenProvider.getEmailFromToken(accessToken);
+        }
+
+        throw new IllegalArgumentException("Invalid or missing Authorization header");
+    }
+
+    public static String extractUserIdentifierFromRequestToken(HttpServletRequest request, TokenProvider tokenProvider) {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String accessToken = authorizationHeader.substring(7);
+            return tokenProvider.getUserIdentifier(accessToken);
+        }
+
+        throw new IllegalArgumentException("Invalid or missing Authorization header");
+    }
 }

--- a/blog-springboot-jpa/src/main/resources/application.properties
+++ b/blog-springboot-jpa/src/main/resources/application.properties
@@ -2,31 +2,38 @@ server.port=8000
 
 #spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+# Sets the Log4jdbc driver to enable SQL logging (helps in tracking SQL queries)
 spring.datasource.driver-class-name=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
 spring.datasource.url=jdbc:log4jdbc:mysql://localhost:3306/blog_jpa?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=root
 spring.datasource.password=root
 
+
+# Uncomment if using standard MySQL dialect (for MySQL versions below 8)
 #spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
-#MySQL8Dialect? MySQL 8.x? ?? ???? ??? ????? ????.
+# Sets Hibernate dialect to MySQL8Dialect for MySQL 8.x versions
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 
+# Disables the "Open Session in View" pattern to avoid keeping database sessions open in the view layer
 spring.jpa.open-in-view=false
 
 spring.jpa.hibernate.ddl-auto=update
 
-# SQL ?? ?? ???
+# Enables SQL logging, showing SQL statements executed by Hibernate
 spring.jpa.show-sql=true
 
-# SQL ?? ??? (?? ??)
+# Formats SQL output to make it more readable (prints SQL statements in an organized format)
 spring.jpa.properties.hibernate.format_sql=true
 
-# ???? ???? ? ??
+# Enables detailed logging for Hibernate parameter values
 spring.jpa.properties.hibernate.type=trace
 
-# Hibernate SQL ??? ?? ??? ??
+# Enables SQL logging for Hibernate at the debug level
+# Logs the SQL query itself every time SQL is executed by Hibernate
 logging.level.org.hibernate.SQL=debug
+
+# Enables tracing for Hibernate SQL parameter binding (shows parameter values in SQL logs)
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=trace
 
 #file & image upload limit settings
@@ -52,3 +59,7 @@ aws.accessKeyId=${AWS_ACCESS_KEY_ID}
 aws.secretKey=${AWS_SECRET_ACCESS_KEY}
 aws.s3.bucketName=${AWS_S3_BUCKET_NAME}
 aws.s3.region=${AWS_REGION}
+
+#redis settings
+spring.redis.host=localhost
+spring.redis.port=6379


### PR DESCRIPTION
1. Redis추가: Docker Desktop 및 Docker Compose 사용. 사용 이유: 불필요한 DB 조회 쿼리를 방지하기 위함
    - 프론트측에서 사용자를 검증할때, 초기 1회만 DB에서 조회하고, Redis에 캐시.
    - 이후에 추가 요청이 왔을 때 redis에 캐시되어 있는 사용자를 반환
    - Redis Config파일 자바 빈 생성 방식으로 구성
    - 관련된 controller, service, repository 로직 구현
    - 구현 방법: user 엔티티 필드에 userIdentifier 필드를 추가해, 사용자가 회원가입을하면 이메일 주소에 @ 앞부분을 userIdentifier 필드 값으로 사용
    - 즉 userIdentifier 컬럼에 사용자 이메일 주소 @앞부분의 값이 사용
    - 이후 프론트로 부터 userIdentifier 동적 경로값을 pathvariable로 받아서 DB에서 조회.
    -  userIdentifier컬럼에 해당 userIdentifier값이 있다면 true 반환 후 redis에 저장. 해당 사용자가 없다면 프론트측에서 404 페이지로 이동

2. 응답을 유연하게 처리하기 위한 sealed 클래스 추가. 사용 이유: 응답 ResponseEntity에 ? 와일드 카드가 아닌, 좀 더 타입을 명확하게 잡고 싶었음.
    - ErrorResponse 및 SuccessResponse로 타입을 제한하여 ReponseEntity 타입에 sealed클래스(ApiResponse) 사용

3. 파일 및, 태그 엔티티 구조 변경 사용 이유: 파일 및, 태그 관련해서 어떤 사용자에 속해있는지 명확하게 구분하기 위함.
    - 기존 로직은 유지한 채, File 엔티티 및 postTag(Many To Many관계에서 중간 역할 엔티티)엔티티에 userId추가

4. s3폴더 구조 변경 사용 이유: 각 사용자마다 고유한 폴더를 통해 파일을 관리할 수 있도록 함.
    - 기존 temp 및 final 방식 -> 사용자명/temp 및 사용자명/final로 변경